### PR TITLE
sysops_archives: création sysops_archives_renew.py pour DRP

### DIFF
--- a/pywikibot/sysops_archives_new.py
+++ b/pywikibot/sysops_archives_new.py
@@ -19,6 +19,7 @@ Différences avec la génération 1.0 :
 NB : La suppression des requêtes traitées reste toujours possible.
 
 Dernières corrections :
+* 3255 : correction d'un problème causé par une page d'archive sans section
 * 3252 : gestion (pas très propre) du paramètre "encours"
 * 3250 : résolution du "bug de la nouvelle année", qui conduisait le bot
 		 à mal archiver les requêtes de la dernière semaine de l'année
@@ -28,13 +29,14 @@ Dernières corrections :
 
 #
 # (C) Toto Azéro, 2011-2016
+# (C) Framawiki, 2018
 #
 # Distribué sous licence GNU GPLv3
 # Distributed under the terms of the GNU GPLv3 license
 # http://www.gnu.org/licenses/gpl.html
 #
-__version__ = '3252'
-__date__ = '2016-02-14 18:45:40 (CET)'
+__version__ = '$Id: sysops_archives_new.py 3255 2016-01-04 22:52:30 (CET) Framawiki $'
+__date__ = '2016-01-04 22:52:30 (CET)'
 #
 
 import almalog2
@@ -411,6 +413,9 @@ class TreatementBot:
 		
 		titres = complements.extract_titles(text, beginning = "", match_title = self.match_titre_requete)
 		sections = complements.extract_sections(text, titres)
+		if not sections:
+			pywikibot.output(u"Aucune section dans la page !")
+			continue
 		
 		now = datetime.datetime.now()
 		#now = now + datetime.timedelta(days=11 - now.day) #debug : pour être le 11#			

--- a/pywikibot/sysops_archives_new.py
+++ b/pywikibot/sysops_archives_new.py
@@ -19,7 +19,8 @@ Différences avec la génération 1.0 :
 NB : La suppression des requêtes traitées reste toujours possible.
 
 Dernières corrections :
-* 3255 : correction d'un problème causé par une page d'archive sans section
+* 3400 : PutQueue with safe_put : tout publier d'un coup,
+         pour chaque page de requêtes
 * 3252 : gestion (pas très propre) du paramètre "encours"
 * 3250 : résolution du "bug de la nouvelle année", qui conduisait le bot
 		 à mal archiver les requêtes de la dernière semaine de l'année
@@ -29,22 +30,56 @@ Dernières corrections :
 
 #
 # (C) Toto Azéro, 2011-2016
-# (C) Framawiki, 2018
 #
 # Distribué sous licence GNU GPLv3
 # Distributed under the terms of the GNU GPLv3 license
 # http://www.gnu.org/licenses/gpl.html
 #
-__version__ = '$Id: sysops_archives_new.py 3255 2016-01-04 22:52:30 (CET) Framawiki $'
-__date__ = '2016-01-04 22:52:30 (CET)'
+__version__ = '3400'
+__date__ = '2016-11-04 19:02:10 (CET)'
 #
 
 import almalog2
 import pywikibot
 from pywikibot import config, page, textlib
-import locale, re
+import locale, re, sys
 import datetime
 import complements
+
+class PutQueue:
+	def __init__(self):
+		self.queue = []
+	
+	def add(self, page, text, comment):
+		self.queue.append((page, text, comment))
+	
+	def safe_put(self, page, text, comment):
+		try:
+			page.put(text, comment = comment)
+		except pywikibot.SpamfilterError as errorBlacklist:
+			text.replace(errorBlacklist.url, "<nowiki>%s</nowiki>" % errorBlacklist)
+			self.site.unlock_page(page) # Strange bug, page locked after the error
+			page.put(text, comment = comment)
+	
+	def put_all(self):
+		total_put = 0
+		try:
+			for li in self.queue:
+				page, text, comment = li
+				self.safe_put(page, text, comment)
+				total_put += 1
+		except Exception, myexception:
+			#e = sys.exc_info()
+			#pywikibot.output(e)
+			
+			if total_put == 0:
+				pywikibot.output("WARNING: Nothing was put, and nothing will be")
+				raise myexception
+			else:
+				pywikibot.output("CRITICAL: Some things were put, you may have to undo changes!")
+				almalog2.error('sysops_archives_new', '\nWhile doing %s\nCRITICAL: Some things were already put, you may have to undo changes!'
+						% page.title())
+				raise myexception
 
 class TreatementBot:
 	def __init__(self, raccourci):
@@ -135,7 +170,7 @@ class TreatementBot:
 		
 		self.match_date = re.compile(u"(?P<day>[0-9]+) *(?P<month>[^ ]+) *(?P<year>20[0-9]{2}) *à *(?P<hours>[0-9]{2}):(?P<minutes>[0-9]{2})")
 		self.match_titre_requete = re.compile(u"(\n|^)== *([^=].+[^=]) *==")
-	
+
 	def analyse_section(self, section, template_title = None):
 		"""
 		Analyse une section et retourne un dictionnaire contenant la date et le statut
@@ -252,6 +287,9 @@ class TreatementBot:
 		'': list() # requêtes sans statut ou ne répondant pas à la contrainte du délai
 		}
 		
+		if not sections:
+			sections = []
+				
 		for numero_section in sections:
 			pywikibot.output('--------------------------------')
 			pywikibot.output(sections[numero_section])
@@ -383,12 +421,12 @@ class TreatementBot:
 		comment = u"Classement des requêtes (%i requête(s) traitée(s), %i requête(s) en attente)" % (len(dict_requetes_par_statut['traitée']), len(dict_requetes_par_statut['attente']))
 		pywikibot.output(self.text)
 		pywikibot.showDiff(self.main_page.get(), self.text)
-		self.main_page.put(self.text, comment = comment)
+		self.put_queue.add(self.main_page, self.text, comment)
 		pywikibot.output(comment)
 		
 		#page = pywikibot.Page(self.site, u"User:ZéroBot/Wikipédia:Requête aux administrateurs/Requêtes traitées")
 		comment = u"Classement des requêtes : %i requête(s) traitée(s)" % len(dict_requetes_par_statut['traitée']) 
-		self.treated_page.put(text_treated, comment = comment)
+		self.put_queue.add(self.treated_page, text_treated, comment)
 		pywikibot.output(comment)
 		
 	def archivage(self):
@@ -413,9 +451,6 @@ class TreatementBot:
 		
 		titres = complements.extract_titles(text, beginning = "", match_title = self.match_titre_requete)
 		sections = complements.extract_sections(text, titres)
-		if not sections:
-			pywikibot.output(u"Aucune section dans la page !")
-			continue
 		
 		now = datetime.datetime.now()
 		#now = now + datetime.timedelta(days=11 - now.day) #debug : pour être le 11#			
@@ -425,6 +460,9 @@ class TreatementBot:
 		requests_to_archive = {}
 		texts_requests_to_archive = {}
 		requests_to_delete = []
+			
+		if not sections:
+			sections = []
 			
 		# Début de la boucle d'analyse de chacune des sections, au cas par cas.
 		for numero_section in sections:
@@ -543,8 +581,9 @@ class TreatementBot:
 						#pywikibot.output('******************************************************')
 						#if archive_page.exists():
 							#pywikibot.showDiff(archive_page.get(), new_text)
-						self.treated_page.put(text, comment = (comment + u" vers %s" % archive_page.title(asLink = True)))
-						archive_page.put(new_text, comment = comment)
+						self.put_queue.add(self.treated_page, text, comment = (comment + u" vers %s" % archive_page.title(asLink = True)))
+						
+						self.put_queue.add(archive_page, new_text, comment = comment)
 					except Exception, myexception:
 						pywikibot.output("erreur type 2 : %s %s" % (type(myexception), myexception.args))
 						#print u'%s %s' % (type(myexception), myexception.args)
@@ -552,17 +591,19 @@ class TreatementBot:
 			
 		elif self.dict['supprimer']:
 			comment = (u"Suppression de %i requêtes" % len(requests_to_delete))
-			self.treated_page.put(text, comment = comment)
-			
+			self.put_queue.add(self.treated_page, text, comment = comment)				
+				
 	def traitement(self):
 		"""
 		Traitement complet des requêtes aux admins :
 			- classement
 			- archivage
 		"""
+		self.put_queue = PutQueue()
 		self.classement()
+		self.put_queue.put_all()
 		self.archivage()
-
+		self.put_queue.put_all()
 
 def main():
 	# Configuration de locale

--- a/pywikibot/sysops_archives_renew.py
+++ b/pywikibot/sysops_archives_renew.py
@@ -2,21 +2,15 @@
 # -*- coding: utf-8  -*-
 
 """
-Classement et archivage des requêtes aux sysops.
+Classement et archivage des requêtes aux sysops (génération 3.0).
 
 Ce script classe les requêtes d'une page de requêtes aux sysops.
 
-TODO (A):
-	- fix error "No text to be save"
-	✓ mettre un 'try' dans les boucles "for numero_section in sections:" pour
-	  éviter qu'une section ne puisse tout faire bugguer… 
-	- faire des fonctions pour les morceaux de codes en doubles (ou plus ?)
+Différences avec la génération 1.0 :
+	- ajout d'un quatrième cas au paramètre status: sanssuite, en plus de rien, oui, non
 	
 Dernières corrections :
-* 2905 : correction d'un problème causé par une page d'archive sans section
-* 2900 : gestion statuts autre et autreavis pour DRP
-* 2855 : gestion de la date (type 7h53 en plus de 7:53)
-* 2853 : correction d'un problème causé par la présence d'un antislash suivi d'un nombre dans la page
+* 
 """
 
 #
@@ -27,11 +21,10 @@ Dernières corrections :
 # Distributed under the terms of the GNU GPLv3 license
 # http://www.gnu.org/licenses/gpl.html
 #
-__version__ = '$Id: sysops_archives.py 2905 2016-01-04 22:52:30 (CET) Framawiki $'
+__version__ = '$Id: sysops_archives_renew.py 4000 2016-01-04 22:52:30 (CET) Framawiki $'
 __date__ = '2016-01-04 22:52:30 (CET)'
 #
 
-import almalog2
 import pywikibot
 from pywikibot import config, page, textlib
 import locale, re
@@ -62,110 +55,17 @@ class TreatementBot:
 		###
 		# Définitions particulières à la page de requêtes
 		###
-		if raccourci == 'ra':
+		if raccourci == 'drp':
 			self.dict = {
-			'archiver': {'acceptees': False, 'refusees': True},
-			'supprimer': {'acceptees': True, 'refusees': False},
-			'delai': {'classement': 12, 'archivage': 4*24, 'suppression': 4*24} # En heures,
-			}
-			
-			self.main_page_test = pywikibot.Page(self.site, u"Utilisateur:ZéroBot/Wikipédia:Requête aux administrateurs")
-			self.accepted_page_test = pywikibot.Page(self.site, u"Utilisateur:ZéroBot/Wikipédia:Requête aux administrateurs/Requêtes traitées")
-			self.refused_page_test = pywikibot.Page(self.site, u"Utilisateur:ZéroBot/Wikipédia:Requête aux administrateurs/Requêtes refusées")
-
-			self.main_page = pywikibot.Page(self.site, u"Wikipédia:Requête aux administrateurs")
-			self.accepted_page = pywikibot.Page(self.site, u"Wikipédia:Requête aux administrateurs/Requêtes traitées")
-			self.refused_page = pywikibot.Page(self.site, u"Wikipédia:Requête aux administrateurs/Requêtes refusées")
-			
-			self.text_below_waiting_requests = u""
-			self.text_below_untreated_requests = u"\n{{Wikipédia:Requête aux administrateurs/Note:Requêtes à traiter}}"
-			self.template_prefix = "RA"
-			self.template_title = u"%s début" % self.template_prefix
-			self.template_end_title = u"%s fin" % self.template_prefix
-			self.archivePrefix = u"Archives"
-			
-		elif raccourci == 'dpp':
-			self.dict = {
-			'archiver': {'acceptees': False, 'refusees': True},
-			'supprimer': {'acceptees': True, 'refusees': False},
-			'delai': {'classement': 24, 'archivage': 7*24, 'suppression': 7*24} # En heures,
-			}
-			
-			self.main_page = pywikibot.Page(self.site, u"Wikipédia:Demande de protection de page")
-			self.accepted_page = pywikibot.Page(self.site, u"Wikipédia:Demande de protection de page/Traitées")
-			self.refused_page = pywikibot.Page(self.site, u"Wikipédia:Demande de protection de page/Refusées")
-			
-			self.text_below_waiting_requests = u"\n{{Wikipédia:Requête aux administrateurs/Note:Requêtes en cours}}"			
-			self.text_below_untreated_requests = u"\n{{Wikipédia:Requête aux administrateurs/Note:Requêtes à traiter}}"
-			self.template_prefix = "DPP"
-			self.template_title = u"%s début" % self.template_prefix
-			self.template_end_title = u"%s fin" % self.template_prefix
-			self.archivePrefix = u"Archives"
-			
-		elif raccourci == 'drp':
-			self.dict = {
-			'archiver': {'acceptees': True, 'refusees': True},
-			'supprimer': {'acceptees': False, 'refusees': False},
+			'archiver': {'acceptees': True, 'refusees': True, 'sanssuite': True},
+			'supprimer': {'acceptees': False, 'refusees': False, 'sanssuite': False},
 			'delai': {'classement': 24, 'archivage': 7*24, 'suppression': 7*24} # En heures,
 			}
 			
 			self.main_page = pywikibot.Page(self.site, u"Wikipédia:Demande de restauration de page")
 			self.accepted_page = pywikibot.Page(self.site, u"Wikipédia:Demande de restauration de page/Traitées")
 			self.refused_page = pywikibot.Page(self.site, u"Wikipédia:Demande de restauration de page/Refusées")
-			
-			self.text_below_waiting_requests = u"\n{{Wikipédia:Requête aux administrateurs/Note:Requêtes en cours}}\n<!-- DEBUT DES REQUÊTES EN COURS =============================================================== -->"			
-			self.text_below_untreated_requests = u"\n{{Wikipédia:Requête aux administrateurs/Note:Requêtes à traiter}}\n<!-- DEBUT DES REQUÊTES A TRAITER ========================================== -->"
-			self.template_prefix = "DRP"
-			self.template_title = u"%s début" % self.template_prefix
-			self.template_end_title = u"%s fin" % self.template_prefix
-			self.archivePrefix = u"Archives"
-			
-		elif raccourci == 'dipp':
-			self.dict = {
-			'archiver': {'acceptees': True, 'refusees': True},
-			'supprimer': {'acceptees': False, 'refusees': False},
-			'delai': {'classement': 24, 'archivage': 7*24, 'suppression': 7*24} # En heures,
-			}
-			
-			self.main_page = pywikibot.Page(self.site, u"Wikipédia:Demande d'intervention sur une page protégée")
-			self.accepted_page = pywikibot.Page(self.site, u"Wikipédia:Demande d'intervention sur une page protégée/Traitées")
-			self.refused_page = pywikibot.Page(self.site, u"Wikipédia:Demande d'intervention sur une page protégée/Refusées")
-			
-			self.text_below_waiting_requests = u"\n{{Wikipédia:Requête aux administrateurs/Note:Requêtes en cours}}\n\n<!-- FIN DES REQUÊTES EN COURS =============================================================== -->"			
-			self.text_below_untreated_requests = u"\n{{Wikipédia:Requête aux administrateurs/Note:Requêtes à traiter}}"
-			self.template_prefix = "DIPP"
-			self.template_title = u"%s début" % self.template_prefix
-			self.template_end_title = u"%s fin" % self.template_prefix
-			self.archivePrefix = u"Archives/"
-			
-		elif raccourci == 'dims':
-			self.dict = {
-			'archiver': {'acceptees': True, 'refusees': True},
-			'supprimer': {'acceptees': False, 'refusees': False},
-			'delai': {'classement': 48, 'archivage': 15*24, 'suppression': 15*24} # En heures,
-			}
-			
-			self.main_page = pywikibot.Page(self.site, u"Wikipédia:Demande d'intervention sur un message système")
-			self.accepted_page = pywikibot.Page(self.site, u"Wikipédia:Demande d'intervention sur un message système/Traitées")
-			self.refused_page = pywikibot.Page(self.site, u"Wikipédia:Demande d'intervention sur un message système/Refusées")
-			
-			self.text_below_waiting_requests = u""			
-			self.text_below_untreated_requests = u"\n{{Wikipédia:Requête aux administrateurs/Note:Requêtes à traiter}}"
-			self.template_prefix = "DIMS"
-			self.template_title = u"%s début" % self.template_prefix
-			self.template_end_title = u"%s fin" % self.template_prefix
-			self.archivePrefix = u"Archives"
-			
-		elif raccourci == 'test':
-			self.dict = {
-			'archiver': {'acceptees': False, 'refusees': True},
-			'supprimer': {'acceptees': True, 'refusees': False},
-			'delai': {'classement': 24, 'archivage': 7*24, 'suppression': 7*24} # En heures,
-			}
-			
-			self.main_page = pywikibot.Page(self.site, u"User:ZéroBot/Wikipédia:Demande de restauration de page")
-			self.accepted_page = pywikibot.Page(self.site, u"User:ZéroBot/Wikipédia:Demande de restauration de page/Traitées")
-			self.refused_page = pywikibot.Page(self.site, u"User:ZéroBot/Wikipédia:Demande de restauration de page/Refusées")
+			self.sanssuite_page = pywikibot.Page(self.site, u"Wikipédia:Demande de restauration de page/Sans suite")
 			
 			self.text_below_waiting_requests = u"\n{{Wikipédia:Requête aux administrateurs/Note:Requêtes en cours}}\n<!-- DEBUT DES REQUÊTES EN COURS =============================================================== -->"			
 			self.text_below_untreated_requests = u"\n{{Wikipédia:Requête aux administrateurs/Note:Requêtes à traiter}}\n<!-- DEBUT DES REQUÊTES A TRAITER ========================================== -->"
@@ -236,6 +136,7 @@ class TreatementBot:
 			- 'oui' : la requête a été acceptée
 			- 'non' : la requête a été refusée
 			- 'attente' : la requête est en attente
+			- 'sanssuite' : la requête est close et n'a donnée aucune suite
 		
 		Si le paramètre statut n'est pas renseigné, où s'il ne correspond à aucun des
 		trois statuts connus par le bot, celui-ci ignore la requête, et la laisse où
@@ -298,6 +199,7 @@ class TreatementBot:
 		'oui': list(),
 		'non': list(),
 		'attente': list(),
+		'sanssuite': list(),
 		'': list() # requêtes sans statut ou ne répondant pas à la contrainte du délai
 		}
 		
@@ -314,7 +216,7 @@ class TreatementBot:
 			pywikibot.output('date found: %s' % date)
 			pywikibot.output('statut found: %s' % statut)
 			
-			if statut not in ['oui', 'non', 'attente', 'autreavis', 'autre']:
+			if statut not in ['oui', 'non', 'attente', 'autreavis', 'autre', 'sanssuite']:
 				# Le statut de la requête n'est pas reconnu ou pas pris en charge
 				continue
 			
@@ -405,9 +307,15 @@ class TreatementBot:
 		if text_refused:
 			while text_refused[-2:] != '\n\n':
 				text_refused += '\n'
-
 		for requete in dict_requetes_par_statut['non']:
 			text_refused += requete
+			
+		text_sanssuite = self.sanssuite_page.get()
+		if text_sanssuite:
+			while text_sanssuite[-2:] != '\n\n':
+				text_sanssuite += '\n'
+		for requete in dict_requetes_par_statut['sanssuite']:
+			text_sanssuite += requete
 		
 		text_waiting = ""
 		for requete in dict_requetes_par_statut['attente']:
@@ -437,7 +345,7 @@ class TreatementBot:
 		self.text = re.sub(u"\n+(= *[rR]equêtes *à *traiter *= *)", u"\n%s\\1" % text_waiting.replace('\\', u'{[(+-/antislash/-+)]}'), self.text)
 		self.text = self.text.replace(u"{[(+-/antislash/-+)]}", '\\')
 		
-		comment = u"Classement des requêtes (%i requête(s) acceptée(s), %i requête(s) refusée(s), %i requête(s) en attente)" % (len(dict_requetes_par_statut['oui']), len(dict_requetes_par_statut['non']), len(dict_requetes_par_statut['attente']))
+		comment = u"Classement des requêtes (%i requête(s) acceptée(s), %i requête(s) refusée(s), %i requête(s) en attente, %i requête(s) classées sans suite)" % (len(dict_requetes_par_statut['oui']), len(dict_requetes_par_statut['non']), len(dict_requetes_par_statut['attente']), len(dict_requetes_par_statut['sanssuite']))
 		#pywikibot.output(self.text)
 		#pywikibot.showDiff(self.main_page.get(), self.text)
 		self.main_page.put(self.text, comment = comment)
@@ -449,6 +357,10 @@ class TreatementBot:
 		
 		comment = u"Classement des requêtes : %i requête(s) refusée(s)" % len(dict_requetes_par_statut['non'])
 		self.refused_page.put(text_refused, comment = comment)
+		pywikibot.output(comment)
+		
+		comment = u"Classement des requêtes : %i requête(s) sanssuite(s)" % len(dict_requetes_par_statut['sanssuite'])
+		self.sanssuite_page.put(text_sanssuite, comment = comment)
 		pywikibot.output(comment)
 		
 	def archivage(self):
@@ -467,13 +379,16 @@ class TreatementBot:
 			  d'archives est créée.
 			- vérifier l.475 (new_text = archive_page.get() + '\\n' + text_to_archive)
 		"""
-		to_do = ['acceptees', 'refusees']
+		to_do = ['acceptees', 'refusees', 'sanssuite']
 		for type in to_do:
 			if type == 'acceptees':
 				page_en_cours = self.accepted_page
 				#text = self.accepted_page.get()
 			elif type == 'refusees':
 				page_en_cours = self.refused_page
+				#text = self.refused_page.get()
+			elif type == 'sanssuite':
+				page_en_cours = self.sanssuite_page
 				#text = self.refused_page.get()
 			pywikibot.output(page_en_cours)
 			
@@ -690,7 +605,7 @@ class TreatementBot:
 			- classement
 			- archivage
 		"""
-		self.classement()
+		#self.classement()
 		self.archivage()
 
 
@@ -701,10 +616,9 @@ def main():
 	except:
 		locale.setlocale(locale.LC_ALL, 'fr_FR')
 	
-	liste_raccourcis = ['dr', 'dpp', 'dipp', 'dims']
+	liste_raccourcis = ['drp']
 	
 	for raccourci in liste_raccourcis:
-		try:
 			pywikibot.output(u"""
 ************************************************
 |              TRAITEMENT DE %s              |
@@ -715,18 +629,6 @@ def main():
 ************************************************
 |          FIN DU TRAITEMENT DE %s            |
 ************************************************""" %  raccourci)
-		except Exception, myexception:
-			pywikibot.output(u'erreur lors du traitement de %s' % raccourci)
-			pywikibot.output(u'%s %s' % (type(myexception), myexception.args))
-			continue
 	
 if __name__ == '__main__':
-    try:
-        main()
-    except Exception, myexception:
-        almalog2.error(u'sysops_archives', u'%s %s'% (type(myexception), myexception.args))
-        #print u'%s %s' % (type(myexception), myexception.args)
-        raise
-    finally:
-        almalog2.writelogs(u'sysops_archives')
-        pywikibot.stopme()
+    main()


### PR DESCRIPTION
sysops_archives_renew.py est un fork de sysops_archives.py pour pouvoir prendre en compte le noueau cachier des charges de WP:DRP

Cf https://fr.wikipedia.org/wiki/Discussion_utilisateur:Toto_Az%C3%A9ro#Bot_en_DRP
https://fr.wikipedia.org/wiki/Wikip%C3%A9dia:Bot/Requ%C3%AAtes/2018/06#Z%C3%A9roBot_-_changement_des_messages_concernant_les_DRP

+ fix #6
Déjà en prod

Si on pouvait trouver une alternative à ces multiples fichiers similaires, et leurs noms originaux :)